### PR TITLE
Refactor spotbug

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -129,6 +129,7 @@ public class CommandLineOptions implements Options {
   private static final String PROXY_PASS_THROUGH = "proxy-pass-through";
   private static final String SUPPORTED_PROXY_ENCODINGS = "supported-proxy-encodings";
   private static final String WEBHOOK_THREADPOOL_SIZE = "webhook-threadpool-size";
+  private static final String DEFAULT_PASSWORD = "password";
 
   private final OptionSet optionSet;
 
@@ -177,7 +178,7 @@ public class CommandLineOptions implements Options {
     optionParser
         .accepts(HTTPS_TRUSTSTORE_PASSWORD, "Password for the trust store")
         .withRequiredArg()
-        .defaultsTo("password");
+        .defaultsTo(DEFAULT_PASSWORD);
     optionParser
         .accepts(
             HTTPS_TRUSTSTORE,
@@ -192,13 +193,13 @@ public class CommandLineOptions implements Options {
     optionParser
         .accepts(HTTPS_KEYSTORE_PASSWORD, "Password for the alternative keystore.")
         .withRequiredArg()
-        .defaultsTo("password");
+        .defaultsTo(DEFAULT_PASSWORD);
     optionParser
         .accepts(
             HTTPS_KEY_MANAGER_PASSWORD,
             "Key manager password for use with the alternative keystore.")
         .withRequiredArg()
-        .defaultsTo("password");
+        .defaultsTo(DEFAULT_PASSWORD);
     optionParser
         .accepts(
             HTTPS_KEYSTORE,

--- a/src/test/java/com/github/tomakehurst/wiremock/ContentPatternsJsonValidityTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ContentPatternsJsonValidityTest.java
@@ -27,6 +27,8 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import com.networknt.schema.*;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 import org.hamcrest.Matchers;
@@ -61,7 +63,7 @@ public class ContentPatternsJsonValidityTest {
 
   @Test
   void binaryEqualToValidates() {
-    assertThat(validate(binaryEqualTo("abc".getBytes())), empty());
+    assertThat(validate(binaryEqualTo("abc".getBytes(StandardCharsets.UTF_8))), empty());
     assertThat(validate("{ \"binaryEqualTo\": \"not base 64\" }"), Matchers.not(empty()));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -80,7 +80,7 @@ public class HttpsBrowserProxyAcceptanceTest {
       tempNonExistingPath("wiremock-keystores", "ca-keystore.jks");
 
   @RegisterExtension
-  public static WireMockExtension target =
+  public static final WireMockExtension target =
       WireMockExtension.newInstance()
           .options(
               options()
@@ -90,7 +90,7 @@ public class HttpsBrowserProxyAcceptanceTest {
           .build();
 
   @RegisterExtension
-  public static WireMockExtension proxy =
+  public static final WireMockExtension proxy =
       WireMockExtension.newInstance()
           .options(
               options()

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
@@ -52,7 +52,7 @@ public class HttpsBrowserProxyClientAuthAcceptanceTest {
       tempNonExistingPath("wiremock-keystores", "ca-keystore.jks");
 
   @RegisterExtension
-  public static WireMockExtension target =
+  public static final WireMockExtension target =
       WireMockExtension.newInstance()
           .options(
               options()
@@ -89,7 +89,7 @@ public class HttpsBrowserProxyClientAuthAcceptanceTest {
     assertThat(EntityUtils.toString(response.getEntity()), is("Success"));
   }
 
-  private static String tempNonExistingPath(String prefix, String filename) {
+  private static final String tempNonExistingPath(String prefix, String filename) {
     try {
       Path tempDirectory = Files.createTempDirectory(prefix);
       return tempDirectory.resolve(filename).toFile().getAbsolutePath();

--- a/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.http.JvmProxyConfigurer;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -117,7 +118,7 @@ public class JvmProxyConfigAcceptanceTest {
   private String getContentUsingDefaultJvmHttpClient(String url) throws Exception {
     final HttpURLConnection urlConnection = (HttpURLConnection) new URL(url).openConnection();
     try (InputStream in = urlConnection.getInputStream()) {
-      return new String(in.readAllBytes());
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
     }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.hc.client5.http.entity.mime.*;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -96,7 +97,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
         post("/multipart-mixed")
             .withMultipartRequestBody(aMultipart().withName("text").withBody(containing("hello")))
             .withMultipartRequestBody(
-                aMultipart().withName("file").withBody(binaryEqualTo("ABCD".getBytes())))
+                aMultipart().withName("file").withBody(binaryEqualTo("ABCD".getBytes(StandardCharsets.UTF_8))))
             .willReturn(ok()));
 
     ClassicHttpRequest request =
@@ -105,7 +106,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
                 MultipartEntityBuilder.create()
                     .setMimeSubtype("mixed")
                     .addTextBody("text", "hello")
-                    .addBinaryBody("file", "ABCD".getBytes())
+                    .addBinaryBody("file", "ABCD".getBytes(StandardCharsets.UTF_8))
                     .build())
             .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -37,7 +37,7 @@ public class MultipartTemplatingAcceptanceTest {
   WireMockTestClient client;
 
   @RegisterExtension
-  public static WireMockExtension wm =
+  public static final WireMockExtension wm =
       WireMockExtension.newInstance()
           .options(options().dynamicPort().templatingEnabled(true).globalTemplating(true))
           .build();

--- a/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
@@ -41,14 +41,14 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class StubLifecycleListenerAcceptanceTest {
 
-  TestStubLifecycleListener loggingListener = new TestStubLifecycleListener();
-  ExceptionThrowingStubLifecycleListener exceptionThrowingListener =
+  static TestStubLifecycleListener loggingListener = new TestStubLifecycleListener();
+  static ExceptionThrowingStubLifecycleListener exceptionThrowingListener =
       new ExceptionThrowingStubLifecycleListener();
 
   @TempDir public static File tempDir;
 
   @RegisterExtension
-  public WireMockExtension wm =
+  public static final WireMockExtension wm =
       WireMockExtension.newInstance()
           .options(
               options()

--- a/src/test/java/com/github/tomakehurst/wiremock/StubMetadataAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubMetadataAcceptanceTest.java
@@ -56,8 +56,8 @@ public class StubMetadataAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(four.getString("five"), is("55555"));
 
-    List<?> six = metadata.getList("six");
-    assertThat((Integer) six.get(0), is(1));
+    List<Integer> six = metadata.getList("six");
+    assertThat(six.get(0), is(1));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -88,7 +88,7 @@ public class WireMockJUnitRuleTest {
   public static class WireMockRuleAsJUnit411ClassRule {
 
     @ClassRule
-    public static WireMockClassRule classRule =
+    public static final WireMockClassRule classRule =
         new WireMockClassRule(wireMockConfig().dynamicPort());
 
     @Rule public WireMockClassRule instanceRule = classRule;
@@ -121,13 +121,13 @@ public class WireMockJUnitRuleTest {
   class WireMockJournalIsResetBetweenMultipleTestsWithWireMockRuleAsJUnit411ClassRule {
 
     @ClassRule
-    public static WireMockClassRule wireMockRule1 =
+    public static final WireMockClassRule wireMockRule1 =
         new WireMockClassRule(wireMockConfig().dynamicPort());
 
     @Rule public WireMockClassRule instancewireMockRule1 = wireMockRule1;
 
     @ClassRule
-    public static WireMockClassRule wireMockRule2 =
+    public static final WireMockClassRule wireMockRule2 =
         new WireMockClassRule(wireMockConfig().dynamicPort());
 
     @Rule public WireMockClassRule instancewireMockRule2 = wireMockRule2;
@@ -176,7 +176,7 @@ public class WireMockJUnitRuleTest {
         new WireMockRule(wireMockConfig().port(RULE_HTTP_PORT).httpsPort(RULE_HTTPS_PORT));
 
     @ClassRule
-    public static WireMockClassRule wireMockClassRule =
+    public static final WireMockClassRule wireMockClassRule =
         new WireMockClassRule(
             wireMockConfig().port(CLASSRULE_HTTP_PORT).httpsPort(CLASSRULE_HTTPS_PORT));
 
@@ -209,11 +209,11 @@ public class WireMockJUnitRuleTest {
     public static final int PORT4 = Network.findFreePort();
 
     @ClassRule
-    public static WireMockClassRule serviceOne =
+    public static final WireMockClassRule serviceOne =
         new WireMockClassRule(wireMockConfig().port(PORT1));
 
     @ClassRule
-    public static WireMockClassRule serviceTwo =
+    public static final WireMockClassRule serviceTwo =
         new WireMockClassRule(wireMockConfig().port(PORT2));
 
     @Rule public WireMockRule serviceThree = new WireMockRule(wireMockConfig().port(PORT3));

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2AcceptanceTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class Http2AcceptanceTest {
 
   @RegisterExtension
-  public static WireMockExtension wm =
+  public static final WireMockExtension wm =
       WireMockExtension.newInstance()
           .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
           .build();

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
@@ -21,14 +21,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
-  @WireMockTest
-  public static class TestSaneStaticDefaults {
+    @Nested
+    @WireMockTest
+  class TestSaneStaticDefaults {
     @RegisterExtension
-    public static WireMockExtension wms =
+    public static final WireMockExtension wms =
         WireMockExtension.newInstance().options(wireMockConfig().port(44345)).build();
 
     @Test
@@ -53,10 +55,11 @@ public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
     }
   }
 
-  @WireMockTest(httpPort = 44777)
-  public static class TestNoStaticOverride {
+    @Nested
+    @WireMockTest(httpPort = 44777)
+  class TestNoStaticOverride {
     @RegisterExtension
-    public static WireMockExtension wms =
+    public static final WireMockExtension wms =
         WireMockExtension.newInstance().options(wireMockConfig().port(44346)).build();
 
     @Test
@@ -69,10 +72,11 @@ public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
     }
   }
 
-  @WireMockTest
-  public static class TestSaneInstanceDefaults {
+    @Nested
+    @WireMockTest
+  class TestSaneInstanceDefaults {
     @RegisterExtension
-    public WireMockExtension wmi =
+    public static WireMockExtension wmi =
         WireMockExtension.newInstance().options(wireMockConfig().port(44349)).build();
 
     @Test
@@ -97,10 +101,11 @@ public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
     }
   }
 
-  @WireMockTest(httpPort = 44778)
-  public static class TestNoInstanceOverride {
+    @Nested
+    @WireMockTest(httpPort = 44778)
+  class TestNoInstanceOverride {
     @RegisterExtension
-    public WireMockExtension wmi =
+    public static WireMockExtension wmi =
         WireMockExtension.newInstance().options(wireMockConfig().port(44351)).build();
 
     @Test

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -32,6 +32,14 @@ public class AdminRoutes {
   private final ImmutableBiMap<RequestSpec, AdminTask> routes;
   private final Iterable<AdminApiExtension> apiExtensions;
   private final Stores stores;
+  private static final String MAPPINGS = "/mappings";
+  private static final String FILES = "/files";
+  private static final String SCENARIOS = "/scenarios";
+  private static final String REQUESTS = "/requests";
+  private static final String RECORDINGS = "/recordings";
+  private static final String NEARMISSES = "/near-misses";
+  private static final String SETTINGS = "/settings";
+  private static final String DOCS = "/docs";
 
   public static AdminRoutes forClient() {
     return new AdminRoutes(Collections.emptyList(), null);
@@ -55,63 +63,63 @@ public class AdminRoutes {
     router.add(GET, "", new RootRedirectTask());
     router.add(POST, "/reset", new ResetTask());
 
-    router.add(GET, "/mappings", new GetAllStubMappingsTask());
-    router.add(POST, "/mappings", new CreateStubMappingTask());
-    router.add(DELETE, "/mappings", new ResetStubMappingsTask());
+    router.add(GET, MAPPINGS, new GetAllStubMappingsTask());
+    router.add(POST, MAPPINGS, new CreateStubMappingTask());
+    router.add(DELETE, MAPPINGS, new ResetStubMappingsTask());
 
     // Deprecated but kept so that 2.x client will still be compatible
-    router.add(POST, "/mappings/edit", new OldEditStubMappingTask());
+    router.add(POST, MAPPINGS + "/edit", new OldEditStubMappingTask());
 
-    router.add(POST, "/mappings/save", new SaveMappingsTask());
-    router.add(POST, "/mappings/reset", new ResetToDefaultMappingsTask());
-    router.add(GET, "/mappings/unmatched", new GetUnmatchedStubMappingsTask());
-    router.add(DELETE, "/mappings/unmatched", new RemoveUnmatchedStubMappingsTask());
-    router.add(GET, "/mappings/{id}", new GetStubMappingTask());
-    router.add(PUT, "/mappings/{id}", new EditStubMappingTask());
-    router.add(POST, "/mappings/remove", new RemoveMatchingStubMappingTask());
-    router.add(DELETE, "/mappings/{id}", new RemoveStubMappingByIdTask());
-    router.add(POST, "/mappings/find-by-metadata", new FindStubMappingsByMetadataTask());
-    router.add(POST, "/mappings/remove-by-metadata", new RemoveStubMappingsByMetadataTask());
-    router.add(POST, "/mappings/import", new ImportStubMappingsTask());
+    router.add(POST, MAPPINGS + "/save", new SaveMappingsTask());
+    router.add(POST, MAPPINGS + "/reset", new ResetToDefaultMappingsTask());
+    router.add(GET, MAPPINGS + "/unmatched", new GetUnmatchedStubMappingsTask());
+    router.add(DELETE, MAPPINGS + "/unmatched", new RemoveUnmatchedStubMappingsTask());
+    router.add(GET, MAPPINGS + "/{id}", new GetStubMappingTask());
+    router.add(PUT, MAPPINGS + "/{id}", new EditStubMappingTask());
+    router.add(POST, MAPPINGS + "/remove", new RemoveMatchingStubMappingTask());
+    router.add(DELETE, MAPPINGS + "/{id}", new RemoveStubMappingByIdTask());
+    router.add(POST, MAPPINGS + "/find-by-metadata", new FindStubMappingsByMetadataTask());
+    router.add(POST, MAPPINGS + "/remove-by-metadata", new RemoveStubMappingsByMetadataTask());
+    router.add(POST, MAPPINGS + "/import", new ImportStubMappingsTask());
 
-    router.add(GET, "/files", new GetAllStubFilesTask(stores));
-    router.add(PUT, "/files/**", new EditStubFileTask(stores));
-    router.add(DELETE, "/files/**", new DeleteStubFileTask(stores));
-    router.add(GET, "/files/**", new GetStubFileTask(stores));
+    router.add(GET, FILES, new GetAllStubFilesTask(stores));
+    router.add(PUT, FILES + "/**", new EditStubFileTask(stores));
+    router.add(DELETE, FILES + "/**", new DeleteStubFileTask(stores));
+    router.add(GET, FILES + "/**", new GetStubFileTask(stores));
 
-    router.add(GET, "/scenarios", new GetAllScenariosTask());
-    router.add(POST, "/scenarios/reset", new ResetScenariosTask());
-    router.add(PUT, "/scenarios/{name}/state", new SetScenarioStateTask());
+    router.add(GET, SCENARIOS, new GetAllScenariosTask());
+    router.add(POST, SCENARIOS + "/reset", new ResetScenariosTask());
+    router.add(PUT, SCENARIOS + "/{name}/state", new SetScenarioStateTask());
 
-    router.add(GET, "/requests", new GetAllRequestsTask());
-    router.add(DELETE, "/requests", new ResetRequestsTask());
-    router.add(POST, "/requests/count", new GetRequestCountTask());
-    router.add(POST, "/requests/find", new FindRequestsTask());
-    router.add(GET, "/requests/unmatched", new FindUnmatchedRequestsTask());
-    router.add(GET, "/requests/unmatched/near-misses", new FindNearMissesForUnmatchedTask());
-    router.add(GET, "/requests/{id}", new GetServedStubTask());
-    router.add(DELETE, "/requests/{id}", new RemoveServeEventTask());
-    router.add(POST, "/requests/remove", new RemoveServeEventsByRequestPatternTask());
-    router.add(POST, "/requests/remove-by-metadata", new RemoveServeEventsByStubMetadataTask());
+    router.add(GET, REQUESTS, new GetAllRequestsTask());
+    router.add(DELETE, REQUESTS, new ResetRequestsTask());
+    router.add(POST, REQUESTS + "/count", new GetRequestCountTask());
+    router.add(POST, REQUESTS + "/find", new FindRequestsTask());
+    router.add(GET, REQUESTS + "/unmatched", new FindUnmatchedRequestsTask());
+    router.add(GET, REQUESTS + "/unmatched/near-misses", new FindNearMissesForUnmatchedTask());
+    router.add(GET, REQUESTS + "/{id}", new GetServedStubTask());
+    router.add(DELETE, REQUESTS + "/{id}", new RemoveServeEventTask());
+    router.add(POST, REQUESTS + "/remove", new RemoveServeEventsByRequestPatternTask());
+    router.add(POST, REQUESTS + "/remove-by-metadata", new RemoveServeEventsByStubMetadataTask());
 
-    router.add(POST, "/recordings/snapshot", new SnapshotTask());
-    router.add(POST, "/recordings/start", new StartRecordingTask());
-    router.add(POST, "/recordings/stop", new StopRecordingTask());
-    router.add(GET, "/recordings/status", new GetRecordingStatusTask());
+    router.add(POST, RECORDINGS + "/snapshot", new SnapshotTask());
+    router.add(POST, RECORDINGS + "/start", new StartRecordingTask());
+    router.add(POST, RECORDINGS + "/stop", new StopRecordingTask());
+    router.add(GET, RECORDINGS + "/status", new GetRecordingStatusTask());
     router.add(GET, "/recorder", new GetRecordingsIndexTask());
 
-    router.add(POST, "/near-misses/request", new FindNearMissesForRequestTask());
-    router.add(POST, "/near-misses/request-pattern", new FindNearMissesForRequestPatternTask());
+    router.add(POST, NEARMISSES + "/request", new FindNearMissesForRequestTask());
+    router.add(POST, NEARMISSES + "/request-pattern", new FindNearMissesForRequestPatternTask());
 
-    router.add(GET, "/settings", new GetGlobalSettingsTask());
-    router.add(PUT, "/settings", new GlobalSettingsUpdateTask());
-    router.add(POST, "/settings", new GlobalSettingsUpdateTask());
-    router.add(PATCH, "/settings/extended", new PatchExtendedSettingsTask());
+    router.add(GET, SETTINGS, new GetGlobalSettingsTask());
+    router.add(PUT, SETTINGS, new GlobalSettingsUpdateTask());
+    router.add(POST, SETTINGS, new GlobalSettingsUpdateTask());
+    router.add(PATCH, SETTINGS + "/extended", new PatchExtendedSettingsTask());
 
     router.add(POST, "/shutdown", new ShutdownServerTask());
 
-    router.add(GET, "/docs/swagger", new GetSwaggerSpecTask());
-    router.add(GET, "/docs", new GetDocIndexTask());
+    router.add(GET, DOCS + "/swagger", new GetSwaggerSpecTask());
+    router.add(GET, DOCS, new GetDocIndexTask());
 
     router.add(GET, "/certs/wiremock-ca.crt", new GetCaCertTask());
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -71,6 +71,7 @@ public class HttpAdminClient implements Admin {
   private final String urlPathPrefix;
   private final String hostHeader;
   private final ClientAuthenticator authenticator;
+  private static final String JSON_CONTENT_TYPE = "application/json";
 
   private final AdminRoutes adminRoutes;
 
@@ -476,14 +477,14 @@ public class HttpAdminClient implements Admin {
 
   private String postJsonAssertOkAndReturnBody(String url, String json) {
     HttpPost post = new HttpPost(url);
-    post.addHeader(CONTENT_TYPE, "application/json");
+    post.addHeader(CONTENT_TYPE, JSON_CONTENT_TYPE);
     post.setEntity(jsonStringEntity(Optional.ofNullable(json).orElse("")));
     return safelyExecuteRequest(url, post);
   }
 
   private String putJsonAssertOkAndReturnBody(String url, String json) {
     HttpPut put = new HttpPut(url);
-    put.addHeader(CONTENT_TYPE, "application/json");
+    put.addHeader(CONTENT_TYPE, JSON_CONTENT_TYPE);
     put.setEntity(jsonStringEntity(Optional.ofNullable(json).orElse("")));
     return safelyExecuteRequest(url, put);
   }
@@ -528,7 +529,7 @@ public class HttpAdminClient implements Admin {
     if (requestSpec.method().hasEntity()) {
       requestBuilder.setEntity(
           jsonStringEntity(Optional.ofNullable(requestBody).map(Json::write).orElse("")));
-      requestBuilder.addHeader(CONTENT_TYPE, "application/json");
+      requestBuilder.addHeader(CONTENT_TYPE, JSON_CONTENT_TYPE);
     }
 
     String responseBodyString = safelyExecuteRequest(url, requestBuilder.build());

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
@@ -30,6 +30,7 @@ public class HttpsSettings {
   private final String trustStorePassword;
   private final String trustStoreType;
   private final boolean needClientAuth;
+  private static final String PASSWORD = "password";
 
   public HttpsSettings(
       int port,
@@ -132,11 +133,11 @@ public class HttpsSettings {
 
     private int port;
     private String keyStorePath = getResource(Builder.class, "keystore").toString();
-    private String keyStorePassword = "password";
-    private String keyManagerPassword = "password";
+    private String keyStorePassword = PASSWORD;
+    private String keyManagerPassword = PASSWORD;
     private String keyStoreType = "JKS";
     private String trustStorePath = null;
-    private String trustStorePassword = "password";
+    private String trustStorePassword = PASSWORD;
     private String trustStoreType = "JKS";
     private boolean needClientAuth = false;
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/Metadata.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/Metadata.java
@@ -53,7 +53,7 @@ public class Metadata extends LinkedHashMap<String, Object> {
     return returnIfValidOrDefaultIfNot(key, String.class, defaultValue);
   }
 
-  public List<?> getList(String key) {
+  public List<Integer> getList(String key) {
     return checkPresenceValidityAndCast(key, List.class);
   }
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 public class WireMockConfiguration implements Options {
 
+  private static final String PASSWORD = "password";
   private long asyncResponseTimeout = DEFAULT_TIMEOUT;
   private boolean disableOptimizeXmlFactoriesLoading = false;
   private int portNumber = DEFAULT_PORT;
@@ -70,11 +71,11 @@ public class WireMockConfiguration implements Options {
 
   private int httpsPort = -1;
   private String keyStorePath = getResource(WireMockConfiguration.class, "keystore").toString();
-  private String keyStorePassword = "password";
-  private String keyManagerPassword = "password";
+  private String keyStorePassword = PASSWORD;
+  private String keyManagerPassword = PASSWORD;
   private String keyStoreType = "JKS";
   private String trustStorePath;
-  private String trustStorePassword = "password";
+  private String trustStorePassword = PASSWORD;
   private String trustStoreType = "JKS";
   private boolean needClientAuth;
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateHelperProviderExtension.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateHelperProviderExtension.java
@@ -19,5 +19,5 @@ import com.github.jknack.handlebars.Helper;
 import java.util.Map;
 
 public interface TemplateHelperProviderExtension extends Extension {
-  Map<String, Helper<?>> provideTemplateHelpers();
+  <T> Map<String, Helper<T>> provideTemplateHelpers();
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -32,15 +32,22 @@ import java.util.*;
 import org.xmlunit.diff.ComparisonType;
 
 public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringValuePattern> {
+  private static final String EQUAL_TO = "equalTo";
+  private static final String EQUAL_TO_JSON = "equalToJson";
+  private static final String MATCHES_JASON_PATH = "matchesJsonPath";
+  private static final String MATCHES_JASON_SCHEMA = "matchesJsonSchema";
+  private static final String EQUAL_TO_XML = "equalToXml";
+  private static final String MATCHES_X_PATH = "matchesXPath";
+  private static final String EXPRESSION = "expression";
 
   private static final Map<String, Class<? extends StringValuePattern>> PATTERNS =
       Map.ofEntries(
-          Map.entry("equalTo", EqualToPattern.class),
-          Map.entry("equalToJson", EqualToJsonPattern.class),
-          Map.entry("matchesJsonPath", MatchesJsonPathPattern.class),
-          Map.entry("matchesJsonSchema", MatchesJsonSchemaPattern.class),
-          Map.entry("equalToXml", EqualToXmlPattern.class),
-          Map.entry("matchesXPath", MatchesXPathPattern.class),
+          Map.entry(EQUAL_TO, EqualToPattern.class),
+          Map.entry(EQUAL_TO_JSON, EqualToJsonPattern.class),
+          Map.entry(MATCHES_JASON_PATH, MatchesJsonPathPattern.class),
+          Map.entry(MATCHES_JASON_SCHEMA, MatchesJsonSchemaPattern.class),
+          Map.entry(EQUAL_TO_XML, EqualToXmlPattern.class),
+          Map.entry(MATCHES_X_PATH, MatchesXPathPattern.class),
           Map.entry("contains", ContainsPattern.class),
           Map.entry("not", NotPattern.class),
           Map.entry("doesNotContain", NegativeContainsPattern.class),
@@ -113,11 +120,11 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
   }
 
   private EqualToPattern deserializeEqualTo(JsonNode rootNode) throws JsonMappingException {
-    if (!rootNode.has("equalTo")) {
+    if (!rootNode.has(EQUAL_TO)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
-    JsonNode equalToNode = rootNode.findValue("equalTo");
+    JsonNode equalToNode = rootNode.findValue(EQUAL_TO);
     if (!equalToNode.isTextual()) {
       throw new JsonMappingException("equalTo operand must be a non-null string");
     }
@@ -129,11 +136,11 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
   }
 
   private EqualToJsonPattern deserializeEqualToJson(JsonNode rootNode) throws JsonMappingException {
-    if (!rootNode.has("equalToJson")) {
+    if (!rootNode.has(EQUAL_TO_JSON)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
-    JsonNode operand = rootNode.findValue("equalToJson");
+    JsonNode operand = rootNode.findValue(EQUAL_TO_JSON);
 
     Boolean ignoreArrayOrder = fromNullable(rootNode.findValue("ignoreArrayOrder"));
     Boolean ignoreExtraElements = fromNullable(rootNode.findValue("ignoreExtraElements"));
@@ -148,11 +155,11 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
 
   private MatchesJsonSchemaPattern deserializeMatchesJsonSchema(JsonNode rootNode)
       throws JsonMappingException {
-    if (!rootNode.has("matchesJsonSchema")) {
+    if (!rootNode.has(MATCHES_JASON_SCHEMA)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
-    JsonNode operand = rootNode.findValue("matchesJsonSchema");
+    JsonNode operand = rootNode.findValue(MATCHES_JASON_SCHEMA);
 
     JsonSchemaVersion schemaVersion;
     try {
@@ -175,11 +182,11 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
   }
 
   private EqualToXmlPattern deserializeEqualToXml(JsonNode rootNode) throws JsonMappingException {
-    if (!rootNode.has("equalToXml")) {
+    if (!rootNode.has(EQUAL_TO_XML)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
-    JsonNode operand = rootNode.findValue("equalToXml");
+    JsonNode operand = rootNode.findValue(EQUAL_TO_XML);
 
     Boolean enablePlaceholders = fromNullable(rootNode.findValue("enablePlaceholders"));
     String placeholderOpeningDelimiterRegex =
@@ -212,20 +219,20 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
 
   private MatchesJsonPathPattern deserialiseMatchesJsonPathPattern(JsonNode rootNode)
       throws JsonMappingException {
-    if (!rootNode.has("matchesJsonPath")) {
+    if (!rootNode.has(MATCHES_JASON_PATH)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
-    JsonNode outerPatternNode = rootNode.findValue("matchesJsonPath");
+    JsonNode outerPatternNode = rootNode.findValue(MATCHES_JASON_PATH);
     if (outerPatternNode.isTextual()) {
       return new MatchesJsonPathPattern(outerPatternNode.textValue());
     }
 
-    if (!outerPatternNode.has("expression")) {
+    if (!outerPatternNode.has(EXPRESSION)) {
       throw new JsonMappingException("expression is required in the advanced matchesJsonPath form");
     }
 
-    String expression = outerPatternNode.findValue("expression").textValue();
+    String expression = outerPatternNode.findValue(EXPRESSION).textValue();
     StringValuePattern valuePattern = buildStringValuePattern(outerPatternNode);
 
     return new MatchesJsonPathPattern(expression, valuePattern);
@@ -233,7 +240,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
 
   private MatchesXPathPattern deserialiseMatchesXPathPattern(JsonNode rootNode)
       throws JsonMappingException {
-    if (!rootNode.has("matchesXPath")) {
+    if (!rootNode.has(MATCHES_X_PATH)) {
       throw new JsonMappingException(rootNode + " is not a valid match operation");
     }
 
@@ -242,16 +249,16 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
     Map<String, String> namespaces =
         namespacesNode != null ? toNamespaceMap(namespacesNode) : Collections.emptyMap();
 
-    JsonNode outerPatternNode = rootNode.findValue("matchesXPath");
+    JsonNode outerPatternNode = rootNode.findValue(MATCHES_X_PATH);
     if (outerPatternNode.isTextual()) {
       return new MatchesXPathPattern(outerPatternNode.textValue(), namespaces);
     }
 
-    if (!outerPatternNode.has("expression")) {
+    if (!outerPatternNode.has(EXPRESSION)) {
       throw new JsonMappingException("expression is required in the advanced matchesXPath form");
     }
 
-    String expression = outerPatternNode.findValue("expression").textValue();
+    String expression = outerPatternNode.findValue(EXPRESSION).textValue();
     StringValuePattern valuePattern = buildStringValuePattern(outerPatternNode);
 
     return new MatchesXPathPattern(expression, namespaces, valuePattern);

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
@@ -64,6 +64,7 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 public class Jetty12HttpServer extends JettyHttpServer {
 
   private ServerConnector mitmProxyConnector;
+  private static final String FALSE = "false";
 
   public Jetty12HttpServer(
       Options options,
@@ -267,7 +268,7 @@ public class Jetty12HttpServer extends JettyHttpServer {
 
     adminContext.setWelcomeFiles(new String[] {"index.html", "index.jsp"});
 
-    adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+    adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", FALSE);
 
     ServletHolder swaggerUiServletHolder =
         adminContext.addServlet(DefaultServlet.class, "/swagger-ui/*");
@@ -320,7 +321,7 @@ public class Jetty12HttpServer extends JettyHttpServer {
     decorateMockServiceContextBeforeConfig(mockServiceContext);
 
     mockServiceContext.setInitParameter("org.eclipse.jetty.servlet.Default.maxCacheSize", "0");
-    mockServiceContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+    mockServiceContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", FALSE);
 
     mockServiceContext.addServlet(DefaultServlet.class, FILES_URL_MATCH);
 
@@ -407,7 +408,7 @@ public class Jetty12HttpServer extends JettyHttpServer {
     filterHolder.setInitParameters(
         Map.of(
             "chainPreflight",
-            "false",
+            FALSE,
             "allowedOrigins",
             "*",
             "allowedHeaders",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Extract hardcoded strings to constants for better maintainability

- Fix SpotBugs and SonarQube code quality issues

- Replace platform-default charset with explicit UTF-8 encoding

- Make static fields final where appropriate


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Strings"] --> B["String Constants"]
  C["Platform Default Charset"] --> D["UTF-8 Encoding"]
  E["Non-final Static Fields"] --> F["Final Static Fields"]
  G["Generic Type Issues"] --> H["Proper Type Parameters"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>CommandLineOptions.java</strong><dd><code>Extract password constant for HTTPS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-c0373e4b1874588b0ce38abc924db611637701108c6c8c67147e71a9973a8a3e">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContentPatternsJsonValidityTest.java</strong><dd><code>Use explicit UTF-8 charset for byte conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-9c7bd9623eee7538684285df1f3b040ad7a2a87b6c71a3bb6b578fad37f8b7a9">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpsBrowserProxyAcceptanceTest.java</strong><dd><code>Make static WireMockExtension fields final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-418023e77d386dfd7d2799c98991e5bdc44bb44d532ffd29c8c80afe48cbbe97">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpsBrowserProxyClientAuthAcceptanceTest.java</strong><dd><code>Make static fields final and fix method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-6befb52dd276d153e59660351a7c1912c338f618461aad4f66f2f7f36909f265">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JvmProxyConfigAcceptanceTest.java</strong><dd><code>Use explicit UTF-8 charset for string conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-22fdd4683a67af9e6f09a02306fa49671be1a7d30715bed4526dc52116020a7e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MultipartBodyMatchingAcceptanceTest.java</strong><dd><code>Use explicit UTF-8 charset for multipart body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-20b22fa87cce2aa7370a203a3bb33c0c580563a207678084c056ab4246fa4fa8">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MultipartTemplatingAcceptanceTest.java</strong><dd><code>Make WireMockExtension field final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-714e34ac2a70a409063f5f3e44099ed0697c82c5bc0adaea8f77241f4ecf5fba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StubLifecycleListenerAcceptanceTest.java</strong><dd><code>Make static fields final and static</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-ebdc44e715e8b5aee51798059d1b20a4ef6692046f3709de64587e9c63005582">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StubMetadataAcceptanceTest.java</strong><dd><code>Fix generic type for metadata list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-974d758870c3060c9e91618bb3c165a1f053a2e4f8c296eb49bd5d4d07a7e4c7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WireMockJUnitRuleTest.java</strong><dd><code>Make static WireMockClassRule fields final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-d57c0a788405d18daff01f3acd25406a89fd7ee3aef69c29292315ca160eb187">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Http2AcceptanceTest.java</strong><dd><code>Make WireMockExtension field final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-98440dae03baae471472612f3b7f0592fc2f4afd33b626d3305fd74c00d0c4f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java</strong><dd><code>Refactor nested classes and make fields final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-a32b404a2a471a03242afc92aa516281da1d9b783e5cd87865e2828c107f5594">+17/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AdminRoutes.java</strong><dd><code>Extract URL path constants for admin routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-ec86c305c5e52e3d7a3e7ac51499a49a435afde43735ca6fe2dae6d8f48a809b">+57/-49</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HttpAdminClient.java</strong><dd><code>Extract JSON content type constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-2c03d41a05eb39bf558ea8b75fe1e444b0152ef609f58934caad34c1858aa5fb">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpsSettings.java</strong><dd><code>Extract password constant for HTTPS settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-19a0d307bfb48d79b7b3e479a910412ac4d10ebe92088db90f32f1d9d265ac1c">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Metadata.java</strong><dd><code>Fix generic type for list method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-5417390a9eb2d0495a2c041fae6888f525e9d8a3a6d525294fc710cbfe78e799">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WireMockConfiguration.java</strong><dd><code>Extract password constant for configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-62893c4bbdbb89fdc48390146f2560e983c7e33a7bd6ef9ff3765d41719b089b">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TemplateHelperProviderExtension.java</strong><dd><code>Fix generic type parameters for template helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-26da05e80dbe03f0ae6ac9391d325ff76e75009ae69f78aecb977925cbf2c1ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StringValuePatternJsonDeserializer.java</strong><dd><code>Extract JSON field name constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-d3c7787cb6eab00fbe3b2bd63f610edb7f10420b36c0bb13115d935608ac1e22">+29/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Jetty12HttpServer.java</strong><dd><code>Extract false string constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/grupo5-ES-2025-1/wiremock/pull/45/files#diff-6a859e0772b580ca8b2ab72f36f3e7fc6062de1b88928318e3c2dd02e07b09e1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

